### PR TITLE
Add verify and deverify command

### DIFF
--- a/app/event.go
+++ b/app/event.go
@@ -69,7 +69,7 @@ func (e *Events) handleIntroductionVerification(m *discordgo.MessageCreate) {
 		return
 	}
 
-	if hasRole, err := e.bot.Utils.UserHasRoleByRoleID(member, e.bot.Cfg.roles.verified); err != nil || hasRole {
+	if hasRole, err := e.bot.Utils.MemberHasRoleByRoleID(member, e.bot.Cfg.roles.verified); err != nil || hasRole {
 		return
 	}
 

--- a/app/msg/greetings.go
+++ b/app/msg/greetings.go
@@ -29,5 +29,7 @@ const (
 const (
 	CommandErase    string = "<Erase>     "
 	CommandForceLog string = "<Force Log> "
-	CommandRemind   string = "<Remind   > "
+	CommandRemind   string = "<Remind>    "
+	CommandVerify   string = "<Verify>    "
+	CommandDeVerify string = "<DeVerify>  "
 )

--- a/app/utils.go
+++ b/app/utils.go
@@ -74,7 +74,7 @@ func (u *Utils) UserHasRoleByRoleName(member *discordgo.Member, roleToFind strin
 }
 
 // Return boolean: does user have role, from role's ID string
-func (u *Utils) UserHasRoleByRoleID(member *discordgo.Member, roleToFind string) (bool, error) {
+func (u *Utils) MemberHasRoleByRoleID(member *discordgo.Member, roleToFind string) (bool, error) {
 
 	for _, userExistingRoleID := range member.Roles {
 		if userExistingRoleID == roleToFind {
@@ -128,9 +128,19 @@ func (u *Utils) IsUserAdmin(userID string) (bool, error) {
 	return u.MemberHasPermission(userID, discordgo.PermissionAdministrator)
 }
 
-func (u *Utils) GetMemberNickOrUsername(user discordgo.Member) string {
-	if user.Nick != "" {
-		return user.Nick
+func (u *Utils) GetMemberNickOrUsername(member discordgo.Member) string {
+	if member.Nick != "" {
+		return member.Nick
 	}
-	return user.User.Username
+	return member.User.Username
+}
+
+func (u *Utils) GetUserNickOrUsername(user *discordgo.User) string {
+
+	member, _ := u.GetMemberByID(user.ID)
+
+	if member.Nick != "" {
+		return member.Nick
+	}
+	return member.User.Username
 }

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/bwmarrin/discordgo v0.26.1 h1:AIrM+g3cl+iYBr4yBxCBp9tD9jR3K7upEjl0d89FRkE=
-github.com/bwmarrin/discordgo v0.26.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/bwmarrin/discordgo v0.27.0 h1:4ZK9KN+rGIxZ0fdGTmgdCcliQeW8Zhu6MnlFI92nf0Q=
 github.com/bwmarrin/discordgo v0.27.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=


### PR DESCRIPTION
Adds `/veriify` command to manually verify someone if the bot didn't promote them before.
`/deverify` will be used to require users to-reverify: this is meant for users who haven't posted in over a year.
