### PR TITLE
Add command to clear intro messages

### DIFF
--- a/app/command.go
+++ b/app/command.go
@@ -436,7 +436,7 @@ func (c *Commands) MultiEraseWithReason(i *discordgo.InteractionCreate, interact
 
 func (c *Commands) ClearIntroductions(i *discordgo.InteractionCreate) {
 
-	messages, err := c.bot.Session.ChannelMessages(c.bot.Cfg.server.intros, 100, "", i.Message.ID, "")
+	messages, err := c.bot.Session.ChannelMessages(c.bot.Cfg.server.intros, 100, "", "", "")
 	if err != nil {
 		c.bot.SendLog(msg.LogError, "Whilst attempting to clear introductions:")
 		c.bot.SendLog(msg.LogError, err.Error())

--- a/app/command.go
+++ b/app/command.go
@@ -451,7 +451,7 @@ func (c *Commands) ClearIntroductions(i *discordgo.InteractionCreate, startingID
 		return
 	}
 
-	messages, err := c.bot.Session.ChannelMessages(c.bot.Cfg.server.intros, 100, "", startingID, "")
+	messages, err := c.bot.Session.ChannelMessages(c.bot.Cfg.server.intros, 100, startingID, "", "")
 	if err != nil {
 		c.bot.SendLog(msg.LogError, "Whilst attempting to clear introductions:")
 		c.bot.SendLog(msg.LogError, err.Error())

--- a/app/command.go
+++ b/app/command.go
@@ -451,7 +451,7 @@ func (c *Commands) ClearIntroductions(i *discordgo.InteractionCreate, startingID
 		return
 	}
 
-	messages, err := c.bot.Session.ChannelMessages(c.bot.Cfg.server.intros, 100, startingID, "", "")
+	messages, err := c.bot.Session.ChannelMessages(c.bot.Cfg.server.intros, 100, "", startingID, "")
 	if err != nil {
 		c.bot.SendLog(msg.LogError, "Whilst attempting to clear introductions:")
 		c.bot.SendLog(msg.LogError, err.Error())
@@ -460,8 +460,7 @@ func (c *Commands) ClearIntroductions(i *discordgo.InteractionCreate, startingID
 	}
 	messageIDs := []string{}
 
-	for i := len(messages) - 1; i > 0; i-- {
-		m := messages[i]
+	for _, m := range messages {
 		if m.Author.ID == c.bot.Cfg.bot.id {
 			messageIDs = append(messageIDs, m.ID)
 		}


### PR DESCRIPTION
This command is a heavy-handed one.
Usually, messages older than 14 days old can't be bulk deleted.
Thus, this command uses looped single-message delete.
It is slower.

Anyway, this command is not meant to be used that often.