### PR TITLE
Add welcome thread and delete bot post feature

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -98,7 +98,7 @@ func main() {
 	fccbot.Events = &Events{bot: fccbot}
 	fccbot.Commands = &Commands{bot: fccbot}
 	// Add intents/permissions
-	fccbot.Session.Identify.Intents = discordgo.IntentsGuildMessages | discordgo.IntentsGuildMembers | discordgo.IntentsAllWithoutPrivileged
+	fccbot.Session.Identify.Intents = discordgo.IntentsGuildMessages | discordgo.IntentsGuildMembers | discordgo.IntentsAllWithoutPrivileged | discordgo.IntentMessageContent
 
 	// Add handlers before open
 	fccbot.Events.Initialize()


### PR DESCRIPTION
This feature adds a process where the bot will automatically start a thread when a user actually verifies themselves,
thank the user, and then clear its own intro-prompting post.

It also adds a restriction to how a user introduces themselves. They now need to use words such as hi, hello, name, etc. lol.
Also the intro message has to be over 15 chars long.